### PR TITLE
Release 0.11.0

### DIFF
--- a/indexer-service/pom.xml
+++ b/indexer-service/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>indexer-service</artifactId>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.6.0</version>
 	<packaging>jar</packaging>
 
 	<!-- Import dependency management from Spring Boot -->

--- a/indexer-service/pom.xml
+++ b/indexer-service/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.8.5</version>
+		<version>0.11.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>indexer-service</artifactId>
-	<version>0.5.0</version>
+	<version>0.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<!-- Import dependency management from Spring Boot -->

--- a/indexer-service/src/main/java/de/cxp/ocs/IndexerController.java
+++ b/indexer-service/src/main/java/de/cxp/ocs/IndexerController.java
@@ -83,7 +83,7 @@ public class IndexerController {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(argEx.getMessage());
 		}
 		catch (IllegalStateException ise) {
-			return ResponseEntity.status(HttpStatus.CONFLICT).build();
+			return ResponseEntity.status(HttpStatus.CONFLICT).body(ise.getMessage());
 		}
 		catch (ExecutionException e) {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/indexer-service/src/main/java/de/cxp/ocs/indexer/IndexItemConverter.java
+++ b/indexer-service/src/main/java/de/cxp/ocs/indexer/IndexItemConverter.java
@@ -82,8 +82,8 @@ public class IndexItemConverter {
 
 		if (sourceDoc.getAttributes() != null) {
 			for (Attribute attribute : sourceDoc.getAttributes()) {
-				if (attribute == null || attribute.value == null || attribute.label == null) continue;
-				fieldConfigIndex.getMatchingFields(attribute.getLabel(), attribute)
+				if (attribute == null || attribute.value == null || attribute.name == null) continue;
+				fieldConfigIndex.getMatchingFields(attribute.name, attribute)
 						.stream()
 						.filter(fieldAtCorrectDocLevelPredicate)
 						.forEach(field -> targetItem.setValue(field, attribute));

--- a/indexer-service/src/main/java/de/cxp/ocs/indexer/model/FacetEntry.java
+++ b/indexer-service/src/main/java/de/cxp/ocs/indexer/model/FacetEntry.java
@@ -27,9 +27,6 @@ public class FacetEntry<T> {
 	@NonNull
 	private Object value;
 
-	// optional attribute value code
-	private String code;
-
 	public FacetEntry(String name) {
 		this.name = name;
 	}

--- a/indexer-service/src/main/java/de/cxp/ocs/indexer/model/FieldUsageApplier.java
+++ b/indexer-service/src/main/java/de/cxp/ocs/indexer/model/FieldUsageApplier.java
@@ -1,9 +1,6 @@
 package de.cxp.ocs.indexer.model;
 
-import static de.cxp.ocs.util.Util.collectObjects;
-import static de.cxp.ocs.util.Util.toNumberCollection;
-import static de.cxp.ocs.util.Util.toStringCollection;
-import static de.cxp.ocs.util.Util.tryToParseAsNumber;
+import static de.cxp.ocs.util.Util.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -182,9 +179,9 @@ public class FieldUsageApplier {
 		}
 		else if (value instanceof Attribute) {
 			Attribute attr = ((Attribute) value);
-			Optional<Number> numberValue = tryToParseAsNumber(attr.getValue());
-			numberValue.map(numVal -> record.getNumberFacetData().add(
-					new FacetEntry<>(field.getName(), attr.getId(), numVal, attr.getCode())));
+			tryToParseAsNumber(attr.getValue())
+					.map(numVal -> record.getNumberFacetData().add(
+							new FacetEntry<>(field.getName(), null, numVal)));
 		}
 		else {
 			Optional<Number> numberValue = tryToParseAsNumber(String.valueOf(value));
@@ -229,7 +226,7 @@ public class FieldUsageApplier {
 		}
 		else if (value instanceof Attribute) {
 			Attribute attr = (Attribute) value;
-			record.getTermFacetData().add(new FacetEntry<>(field.getName(), attr.getId(), attr.getValue(), attr.getCode()));
+			record.getTermFacetData().add(new FacetEntry<>(field.getName(), attr.getCode(), attr.getValue()));
 		}
 		else {
 			record.getTermFacetData().add(new FacetEntry<>(field.getName(), String.valueOf(value)));
@@ -250,7 +247,7 @@ public class FieldUsageApplier {
 			return;
 		}
 		else if (value instanceof Attribute) {
-			fieldName = ((Attribute) value).getLabel();
+			fieldName = ((Attribute) value).getName();
 			numValue = tryToParseAsNumber(((Attribute) value).getValue());
 		}
 		else {

--- a/indexer-service/src/main/java/de/cxp/ocs/util/DocumentDeserializer.java
+++ b/indexer-service/src/main/java/de/cxp/ocs/util/DocumentDeserializer.java
@@ -137,22 +137,19 @@ public class DocumentDeserializer extends JsonDeserializer<Document> {
 	}
 
 	private static Optional<Attribute> extractAttribute(JsonNode treeNode) {
-		JsonNode idNode = treeNode.get("id");
-		JsonNode labelNode = treeNode.get("label");
+		JsonNode nameNode = treeNode.get("name");
 		JsonNode codeNode = treeNode.get("code");
 		JsonNode valueNode = treeNode.get("value");
 
-		if (labelNode == null || labelNode.isMissingNode() || !labelNode.isValueNode()
+		if (nameNode == null || nameNode.isMissingNode() || !nameNode.isValueNode()
 				|| valueNode == null || valueNode.isMissingNode() || !valueNode.isValueNode()
-				|| (idNode != null && !idNode.isValueNode())
 				|| (codeNode != null && !codeNode.isValueNode())) {
 			return Optional.empty();
 		}
 
 		return Optional.of(
 				new Attribute(
-						idNode == null ? null : idNode.textValue(),
-						labelNode.textValue(),
+						nameNode.textValue(),
 						codeNode == null ? null : codeNode.textValue(),
 						valueNode.textValue()));
 	}

--- a/indexer-service/src/main/resources/elasticsearch/_template/structured_search.json
+++ b/indexer-service/src/main/resources/elasticsearch/_template/structured_search.json
@@ -229,10 +229,8 @@
         "type": "nested",
         "properties": {
           "id": {
-            "type": "keyword"
-          },
-          "code": {
-            "type": "keyword"
+            "type": "keyword",
+            "eager_global_ordinals": true
           },
           "name": {
             "type": "keyword",
@@ -247,12 +245,6 @@
       "numberFacetData": {
         "type": "nested",
         "properties": {
-          "id": {
-            "type": "keyword"
-          },
-          "code": {
-            "type": "keyword"
-          },
           "name": {
             "type": "keyword",
             "eager_global_ordinals": true
@@ -266,10 +258,8 @@
         "type": "nested",
         "properties": {
           "id": {
-            "type": "keyword"
-          },
-          "code": {
-            "type": "keyword"
+            "type": "keyword",
+            "eager_global_ordinals": true
           },
           "name": {
             "type": "keyword",
@@ -287,6 +277,10 @@
           "termFacetData": {
             "type": "nested",
             "properties": {
+              "id": {
+	            "type": "keyword",
+	            "eager_global_ordinals": true
+	          },
               "name": {
                 "type": "keyword",
                 "eager_global_ordinals": true

--- a/indexer-service/src/test/java/de/cxp/ocs/indexer/IndexItemConverterTest.java
+++ b/indexer-service/src/test/java/de/cxp/ocs/indexer/IndexItemConverterTest.java
@@ -1,8 +1,6 @@
 package de.cxp.ocs.indexer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 
@@ -190,7 +188,7 @@ public class IndexItemConverterTest {
 						.addDynamicField(new Field("attributes").setUsage(FieldUsage.Facet)));
 
 		IndexableItem result = underTest.toIndexableItem(new Document("1")
-				.setAttributes(new Attribute().setLabel("color").setValue("red")));
+				.setAttributes(new Attribute().setName("color").setValue("red")));
 		assertEquals("red", result.getSearchData().get("color"));
 		assertTrue(result.getTermFacetData().isEmpty());
 	}
@@ -203,7 +201,7 @@ public class IndexItemConverterTest {
 						.addDynamicField(new Field("attributes").addSourceName(".*").setUsage(FieldUsage.Facet)));
 
 		IndexableItem result = underTest.toIndexableItem(new Document("1")
-				.setAttributes(new Attribute().setLabel("color").setValue("red")));
+				.setAttributes(new Attribute().setName("color").setValue("red")));
 		assertTrue(result.getSearchData().isEmpty());
 		assertEquals("color", result.getTermFacetData().get(0).getName());
 		assertEquals("red", result.getTermFacetData().get(0).getValue());
@@ -224,8 +222,8 @@ public class IndexItemConverterTest {
 		IndexableItem result = underTest.toIndexableItem(new Document("1")
 				.set("unknown", "must be ignored")
 				.setAttributes(
-						new Attribute().setLabel("color").setValue("red"),
-						new Attribute().setLabel("size").setValue("41.5")));
+						new Attribute().setName("color").setValue("red"),
+						new Attribute().setName("size").setValue("41.5")));
 
 		assertTrue(result.getSearchData().isEmpty());
 		assertTrue(result.getResultData().isEmpty());
@@ -250,7 +248,7 @@ public class IndexItemConverterTest {
 						.addField(new Field("title").setUsage(FieldUsage.Search)));
 
 		IndexableItem result = underTest.toIndexableItem(new Document("1")
-				.setAttributes(new Attribute().setLabel("color").setValue("red")));
+				.setAttributes(new Attribute().setName("color").setValue("red")));
 
 		assertTrue(result.getSearchData().isEmpty());
 		assertTrue(result.getPathFacetData().isEmpty());

--- a/ocs-java-client/pom.xml
+++ b/ocs-java-client/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 
 	<artifactId>ocs-java-client</artifactId>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.6.0</version>
 	<packaging>jar</packaging>
 
 	<description>A ready to use client for the OCS API</description>

--- a/ocs-java-client/pom.xml
+++ b/ocs-java-client/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.9.3</version>
+		<version>0.11.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 
 	<artifactId>ocs-java-client</artifactId>
-	<version>0.5.1</version>
+	<version>0.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<description>A ready to use client for the OCS API</description>

--- a/ocs-java-client/src/main/java/de/cxp/ocs/client/ImportApi.java
+++ b/ocs-java-client/src/main/java/de/cxp/ocs/client/ImportApi.java
@@ -3,6 +3,7 @@ package de.cxp.ocs.client;
 import de.cxp.ocs.api.indexer.ImportSession;
 import de.cxp.ocs.model.index.BulkImportData;
 import de.cxp.ocs.model.index.Document;
+import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
 
@@ -12,20 +13,25 @@ interface ImportApi {
 	ImportSession startImport(@Param("indexName") String indexName, @Param("locale") String locale);
 
 	@RequestLine("POST /indexer-api/v1/full/add")
+	@Headers("Content-Type: application/json")
 	int add(BulkImportData data) throws Exception;
 
 	@RequestLine("POST /indexer-api/v1/full/done")
+	@Headers("Content-Type: application/json")
 	boolean done(ImportSession session) throws Exception;
 
 	@RequestLine("POST /indexer-api/v1/full/cancel")
+	@Headers("Content-Type: application/json")
 	void cancel(ImportSession session);
 
 	@RequestLine("PATCH /indexer-api/v1/update/{indexName}")
+	@Headers("Content-Type: application/json")
 	boolean patchDocument(@Param("indexName") String indexName, Document doc);
 
 	@RequestLine("PUT /indexer-api/v1/update/{indexName}?replaceExisting={replaceExisting}")
+	@Headers("Content-Type: application/json")
 	boolean putDocument(@Param("indexName") String indexName, @Param("replaceExisting") Boolean replaceExisting, Document doc);
 
-	@RequestLine("DELETE /indexer-api/v1/update/{indexName}?id=id")
-	boolean deleteDocument(@Param("indexName") String indexName, String id);
+	@RequestLine("DELETE /indexer-api/v1/update/{indexName}?id={id}")
+	boolean deleteDocument(@Param("indexName") String indexName, @Param("id") String id);
 }

--- a/ocs-java-client/src/main/java/de/cxp/ocs/client/ImportClient.java
+++ b/ocs-java-client/src/main/java/de/cxp/ocs/client/ImportClient.java
@@ -38,6 +38,7 @@ public class ImportClient implements FullIndexationService, UpdateIndexService {
 	 */
 	public ImportClient(String endpointUrl) {
 		this(endpointUrl, f -> {
+			f.encoder(ObjectMapperFactory.createJacksonEncoder());
 			f.decoder(ObjectMapperFactory.createJacksonDecoder());
 			return;
 		});

--- a/ocs-java-client/src/main/java/de/cxp/ocs/client/deserializer/DocumentDeserializer.java
+++ b/ocs-java-client/src/main/java/de/cxp/ocs/client/deserializer/DocumentDeserializer.java
@@ -134,22 +134,19 @@ public class DocumentDeserializer extends JsonDeserializer<Document> {
 	}
 
 	private static Optional<Attribute> extractAttribute(JsonNode treeNode) {
-		JsonNode idNode = treeNode.get("id");
-		JsonNode labelNode = treeNode.get("label");
+		JsonNode nameNode = treeNode.get("name");
 		JsonNode codeNode = treeNode.get("code");
 		JsonNode valueNode = treeNode.get("value");
 
-		if (labelNode == null || labelNode.isMissingNode() || !labelNode.isValueNode()
+		if (nameNode == null || nameNode.isMissingNode() || !nameNode.isValueNode()
 				|| valueNode == null || valueNode.isMissingNode() || !valueNode.isValueNode()
-				|| (idNode != null && !idNode.isValueNode())
 				|| (codeNode != null && !codeNode.isValueNode())) {
 			return Optional.empty();
 		}
 
 		return Optional.of(
 				new Attribute(
-						idNode == null ? null : idNode.textValue(),
-						labelNode.textValue(),
+						nameNode.textValue(),
 						codeNode == null ? null : codeNode.textValue(),
 						valueNode.textValue()));
 	}

--- a/ocs-java-client/src/main/java/de/cxp/ocs/client/deserializer/FacetEntryDeserializer.java
+++ b/ocs-java-client/src/main/java/de/cxp/ocs/client/deserializer/FacetEntryDeserializer.java
@@ -50,6 +50,7 @@ public class FacetEntryDeserializer extends JsonDeserializer<FacetEntry> {
 			entry = new FacetEntry();
 		}
 
+		Optional.ofNullable((JsonNode) docNode.get("id")).map(JsonNode::textValue).ifPresent(entry::setId);
 		Optional.ofNullable((JsonNode) docNode.get("docCount")).map(JsonNode::asLong).ifPresent(entry::setDocCount);
 		Optional.ofNullable((JsonNode) docNode.get("key")).map(JsonNode::textValue).ifPresent(entry::setKey);
 		Optional.ofNullable((JsonNode) docNode.get("link")).map(JsonNode::textValue).ifPresent(entry::setLink);

--- a/ocs-java-client/src/main/java/de/cxp/ocs/client/deserializer/ObjectMapperFactory.java
+++ b/ocs-java-client/src/main/java/de/cxp/ocs/client/deserializer/ObjectMapperFactory.java
@@ -15,12 +15,18 @@ import de.cxp.ocs.model.params.SearchQuery;
 import de.cxp.ocs.model.result.Facet;
 import de.cxp.ocs.model.result.FacetEntry;
 import feign.codec.Decoder;
+import feign.codec.Encoder;
 import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
 
 public class ObjectMapperFactory {
 
 	public static Decoder createJacksonDecoder() {
 		return new JacksonDecoder(createObjectMapper());
+	}
+
+	public static Encoder createJacksonEncoder() {
+		return new JacksonEncoder(createObjectMapper());
 	}
 
 	public static ObjectMapper createObjectMapper() {

--- a/ocs-java-client/src/test/java/de/cxp/ocs/client/deserializer/SerializationTest.java
+++ b/ocs-java-client/src/test/java/de/cxp/ocs/client/deserializer/SerializationTest.java
@@ -14,9 +14,20 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.cxp.ocs.api.indexer.ImportSession;
-import de.cxp.ocs.model.index.*;
+import de.cxp.ocs.model.index.Attribute;
+import de.cxp.ocs.model.index.Category;
+import de.cxp.ocs.model.index.Document;
+import de.cxp.ocs.model.index.Product;
 import de.cxp.ocs.model.params.SearchQuery;
-import de.cxp.ocs.model.result.*;
+import de.cxp.ocs.model.result.Facet;
+import de.cxp.ocs.model.result.FacetEntry;
+import de.cxp.ocs.model.result.HierarchialFacetEntry;
+import de.cxp.ocs.model.result.IntervalFacetEntry;
+import de.cxp.ocs.model.result.ResultHit;
+import de.cxp.ocs.model.result.SearchResult;
+import de.cxp.ocs.model.result.SearchResultSlice;
+import de.cxp.ocs.model.result.SortOrder;
+import de.cxp.ocs.model.result.Sorting;
 import de.cxp.ocs.model.suggest.Suggestion;
 
 public class SerializationTest {
@@ -62,7 +73,7 @@ public class SerializationTest {
 						.set("title", "string values test"),
 				Attribute.of("a1", "with id"),
 
-				new Attribute("1", "color", "ff0000", "red"),
+				new Attribute("color", "ff0000", "red"),
 
 				new Attribute[] { Attribute.of("1", "fruits"), Attribute.of("2", "apples") },
 
@@ -74,7 +85,7 @@ public class SerializationTest {
 
 				new Product("3")
 						.set("title", "attribute with id test")
-						.setAttributes(new Attribute("1", "color", "ff0000", "red")),
+						.setAttributes(new Attribute("color", "ff0000", "red")),
 
 				new Product("4.1")
 						.set("title", "number array test")

--- a/open-commerce-search-api/pom.xml
+++ b/open-commerce-search-api/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 
 	<artifactId>open-commerce-search-api</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
+	<version>0.9.0</version>
 	<packaging>jar</packaging>
 
 	<description>An open and abstract search API that covers minimal search functionality</description>

--- a/open-commerce-search-api/pom.xml
+++ b/open-commerce-search-api/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.9.3</version>
+		<version>0.11.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 
 	<artifactId>open-commerce-search-api</artifactId>
-	<version>0.8.1</version>
+	<version>0.9.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<description>An open and abstract search API that covers minimal search functionality</description>

--- a/open-commerce-search-api/src/main/java/de/cxp/ocs/model/index/Attribute.java
+++ b/open-commerce-search-api/src/main/java/de/cxp/ocs/model/index/Attribute.java
@@ -9,10 +9,12 @@ import lombok.experimental.Accessors;
 
 @Schema(
 		name = "Attribute",
-		description = "Rich model that can be used to represent a document or product attribute."
-				+ " If 'id' and/or 'code' are provieded, these can be used for consistent filtering, even if the label and values are changing."
-				+ " The label and the values will be used used to produce nice facets or if used for search, they will be added to the searchable content.",
-		example = "{\"id\": \"a.maxSpeed\", \"label\": \"Max Speed\", \"value\": \"230 km/h\", \"code\": 230}")
+		description = "Rich model that can be used to represent a document's or product's attribute."
+				+ " The attribute 'name' should be a URL friendly identifier for that attribute (rather maxSpeed than 'Max Speed')."
+				+ " It will be used as filter parameter laster."
+				+ " If the attribute 'code' is provieded, it can be used for consistent filtering, even if the value name should change."
+				+ " The values are used to produce nice facets or if used for search, they will be added to the searchable content.",
+		example = "{\"name\": \"color\", \"value\": \"red\", \"code\": \"ff0000\"}")
 @Accessors(chain = true)
 @Data
 @NoArgsConstructor
@@ -20,27 +22,26 @@ import lombok.experimental.Accessors;
 public class Attribute {
 	
 	@Schema(
-			description = "Optional: Static ID of that attribute."
-					+ " The id SHOULD be URL friendly, since it could be used to build according filter parameters."
-					+ " If not set, the label could be used for parameter building.",
+			required = true,
+			description = "The name SHOULD be URL friendly identifier for the attribute,"
+					+ " since it could be used to build according filter parameters.",
 			pattern = "[A-Za-z0-9\\-_.]")
-	public String id;
-
-	@Schema(description = "Human readable name of the attribute, e.g. 'Color' or 'Max. Speed in km/h'", required = true)
 	@NonNull
-	public String label;
-	
+	public String name;
+
 	@Schema(
-			description = "Optional: code that represents that attribute value, e.g. \"FF0000\" for color",
+			description = "Optional: code is considered as ID of the attribute value, e.g. \"FF0000\" for color",
 			pattern = "[A-Za-z0-9\\-_.]")
 	public String code;
 
-	@Schema(description = "Human readable representation of that attribute, e.g. 'Red' for the attribute 'Color'", required = true)
+	@Schema(
+			required = true,
+			description = "Human readable representation of that attribute, e.g. 'Red' for the attribute 'Color'")
 	@NonNull
 	public String value;
 
-	public static Attribute of(String label, String value) {
-		return new Attribute(null, label, null, value);
+	public static Attribute of(String name, String value) {
+		return new Attribute(name, null, value);
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>open-commerce-search-api</artifactId>
-				<version>0.8.1</version>
+				<version>0.9.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>de.cxp.ocs</groupId>
 	<artifactId>ocs-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>0.11.0-SNAPSHOT</version>
+	<version>0.11.0</version>
 	<name>SearchHub Services - Parent</name>
 
 	<modules>
@@ -39,7 +39,7 @@
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>open-commerce-search-api</artifactId>
-				<version>0.9.0-SNAPSHOT</version>
+				<version>0.9.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
@@ -49,12 +49,12 @@
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>indexer-service</artifactId>
-				<version>0.5.0</version>
+				<version>0.6.0</version>
 			</dependency>
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>search-service</artifactId>
-				<version>0.9.0-SNAPSHOT</version>
+				<version>0.9.0</version>
 			</dependency>
 			<!-- only including the suggest-service directly, because it depends on 
 				the other suggest modules -->
@@ -66,7 +66,7 @@
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>ocs-java-client</artifactId>
-				<version>0.5.0</version>
+				<version>0.6.0</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>de.cxp.ocs</groupId>
 	<artifactId>ocs-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>0.10.2</version>
+	<version>0.11.0-SNAPSHOT</version>
 	<name>SearchHub Services - Parent</name>
 
 	<modules>
@@ -54,7 +54,7 @@
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>search-service</artifactId>
-				<version>0.7.2</version>
+				<version>0.9.0-SNAPSHOT</version>
 			</dependency>
 			<!-- only including the suggest-service directly, because it depends on 
 				the other suggest modules -->

--- a/search-service/pom.xml
+++ b/search-service/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.10.0</version>
+		<version>0.11.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 
 	<artifactId>search-service</artifactId>
-	<version>0.8.1</version>
+	<version>0.9.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<!-- Import dependency management from Spring Boot -->

--- a/search-service/pom.xml
+++ b/search-service/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.11.0-SNAPSHOT</version>
+		<version>0.11.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 
 	<artifactId>search-service</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
+	<version>0.9.0<version>
 	<packaging>jar</packaging>
 
 	<!-- Import dependency management from Spring Boot -->

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/CategoryFacetCreator.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/CategoryFacetCreator.java
@@ -41,10 +41,10 @@ public class CategoryFacetCreator extends NestedFacetCreator {
 
 	@Override
 	protected AggregationBuilder getNestedValueAggregation(String nestedPathPrefix) {
-		return AggregationBuilders.terms("_values")
+		return AggregationBuilders.terms(FACET_VALUES_AGG)
 				.field(FieldConstants.PATH_FACET_DATA + ".value")
 				.size(maxFacetValues)
-				.subAggregation(AggregationBuilders.terms("_ids")
+				.subAggregation(AggregationBuilders.terms(FACET_IDS_AGG)
 						.field(FieldConstants.PATH_FACET_DATA + ".id")
 						.size(1));
 	}
@@ -66,7 +66,7 @@ public class CategoryFacetCreator extends NestedFacetCreator {
 
 	@Override
 	protected Optional<Facet> createFacet(Bucket facetNameBucket, FacetConfig facetConfig, InternalResultFilter intFacetFilter, SearchQueryBuilder linkBuilder) {
-		Terms categoryAgg = facetNameBucket.getAggregations().get("_values");
+		Terms categoryAgg = facetNameBucket.getAggregations().get(FACET_VALUES_AGG);
 		List<? extends Bucket> catBuckets = categoryAgg.getBuckets();
 		if (catBuckets.size() == 0) return Optional.empty();
 
@@ -101,7 +101,7 @@ public class CategoryFacetCreator extends NestedFacetCreator {
 			lastLevelEntry.setDocCount(docCount);
 			lastLevelEntry.setPath(categoryPath);
 
-			Terms idsAgg = (Terms) categoryBucket.getAggregations().get("_ids");
+			Terms idsAgg = (Terms) categoryBucket.getAggregations().get(FACET_IDS_AGG);
 			if (idsAgg != null && idsAgg.getBuckets().size() > 0) {
 				lastLevelEntry.setId(idsAgg.getBuckets().get(0).getKeyAsString());
 

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/CategoryFacetCreator.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/CategoryFacetCreator.java
@@ -139,7 +139,7 @@ public class CategoryFacetCreator extends NestedFacetCreator {
 	}
 
 	private HierarchialFacetEntry toFacetEntry(String value, String categoryPath, FacetConfig facetConfig, SearchQueryBuilder linkBuilder) {
-		boolean isSelected = linkBuilder.isFilterSelected(facetConfig, categoryPath);
+		boolean isSelected = linkBuilder.isFilterSelected(facetConfig.getSourceField(), categoryPath);
 		String link;
 		if (isSelected) {
 			link = linkBuilder.withoutFilterAsLink(facetConfig, categoryPath);

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/NestedFacetCreator.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/NestedFacetCreator.java
@@ -36,6 +36,7 @@ public abstract class NestedFacetCreator implements FacetCreator {
 	static final String	FILTERED_AGG		= "_filtered";
 	static final String	FACET_NAMES_AGG		= "_names";
 	static final String	FACET_VALUES_AGG	= "_values";
+	static final String	FACET_IDS_AGG		= "_ids";
 
 	@Setter
 	private int maxFacets = 2;

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/TermFacetCreator.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/TermFacetCreator.java
@@ -25,8 +25,6 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class TermFacetCreator extends NestedFacetCreator {
 
-	private final static String CODE_VALUE_AGG = "_code";
-
 	@Setter
 	private int maxFacetValues = 100;
 
@@ -59,8 +57,8 @@ public class TermFacetCreator extends NestedFacetCreator {
 		return AggregationBuilders.terms(FACET_VALUES_AGG)
 				.field(nestedPathPrefix + ".value")
 				.size(maxFacetValues)
-				.subAggregation(AggregationBuilders.terms(CODE_VALUE_AGG)
-						.field(nestedPathPrefix + ".code")
+				.subAggregation(AggregationBuilders.terms(FACET_IDS_AGG)
+						.field(nestedPathPrefix + ".id")
 						.size(1));
 	}
 
@@ -89,7 +87,7 @@ public class TermFacetCreator extends NestedFacetCreator {
 			String facetValue = valueBucket.getKeyAsString();
 
 			String facetValueId = null;
-			Terms facetValueAgg = (Terms) valueBucket.getAggregations().get(CODE_VALUE_AGG);
+			Terms facetValueAgg = (Terms) valueBucket.getAggregations().get(FACET_IDS_AGG);
 			if (facetValueAgg != null && facetValueAgg.getBuckets().size() > 0) {
 				facetValueId = facetValueAgg.getBuckets().get(0).getKeyAsString();
 			}

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/TermFacetCreator.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/TermFacetCreator.java
@@ -80,7 +80,7 @@ public class TermFacetCreator extends NestedFacetCreator {
 
 	private void fillFacet(Facet facet, Bucket facetNameBucket, TermResultFilter facetFilter, FacetConfig facetConfig, SearchQueryBuilder linkBuilder) {
 		Terms facetValues = ((Terms) facetNameBucket.getAggregations().get(FACET_VALUES_AGG));
-		Set<String> filterValues = asSet(facetFilter.getValues());
+		Set<String> filterValues = facetFilter == null ? Collections.emptySet() : asSet(facetFilter.getValues());
 		long absDocCount = 0;
 		for (Bucket valueBucket : facetValues.getBuckets()) {
 			long docCount = getDocumentCount(valueBucket);
@@ -121,9 +121,7 @@ public class TermFacetCreator extends NestedFacetCreator {
 				}
 			}
 
-			FacetEntry facetEntry = new FacetEntry(facetValue, facetValueId, docCount, link, isSelected);
-
-			facet.addEntry(facetEntry);
+			facet.addEntry(new FacetEntry(facetValue, facetValueId, docCount, link, isSelected));
 			absDocCount += docCount;
 		}
 		facet.setAbsoluteFacetCoverage(absDocCount);

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/TermFacetCreator.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/facets/TermFacetCreator.java
@@ -1,7 +1,10 @@
 package de.cxp.ocs.elasticsearch.facets;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -21,6 +24,8 @@ import lombok.experimental.Accessors;
 
 @Accessors(chain = true)
 public class TermFacetCreator extends NestedFacetCreator {
+
+	private final static String CODE_VALUE_AGG = "_code";
 
 	@Setter
 	private int maxFacetValues = 100;
@@ -53,7 +58,10 @@ public class TermFacetCreator extends NestedFacetCreator {
 	protected AggregationBuilder getNestedValueAggregation(String nestedPathPrefix) {
 		return AggregationBuilders.terms(FACET_VALUES_AGG)
 				.field(nestedPathPrefix + ".value")
-				.size(maxFacetValues);
+				.size(maxFacetValues)
+				.subAggregation(AggregationBuilders.terms(CODE_VALUE_AGG)
+						.field(nestedPathPrefix + ".code")
+						.size(1));
 	}
 
 	@Override
@@ -62,55 +70,76 @@ public class TermFacetCreator extends NestedFacetCreator {
 		Facet facet = FacetFactory.create(facetConfig, FacetType.term);
 		if (facetFilter != null && facetFilter instanceof TermResultFilter) {
 			facet.setFiltered(true);
-			if (facetConfig.isMultiSelect() || facetConfig.isShowUnselectedOptions()) {
-				fillFacet(facet, facetNameBucket, facetConfig, linkBuilder);
-			}
-			else {
-				fillSingleSelectFacet(facetNameBucket, facet, (TermResultFilter) facetFilter, facetConfig, linkBuilder);
-			}
+			fillFacet(facet, facetNameBucket, (TermResultFilter) facetFilter, facetConfig, linkBuilder);
 		}
 		else {
 			// unfiltered facet
-			fillFacet(facet, facetNameBucket, facetConfig, linkBuilder);
+			fillFacet(facet, facetNameBucket, null, facetConfig, linkBuilder);
 		}
 
 		return facet.entries.isEmpty() ? Optional.empty() : Optional.of(facet);
 	}
 
-	private void fillSingleSelectFacet(Bucket facetNameBucket, Facet facet, TermResultFilter facetFilter, FacetConfig facetConfig,
-			SearchQueryBuilder linkBuilder) {
+	private void fillFacet(Facet facet, Bucket facetNameBucket, TermResultFilter facetFilter, FacetConfig facetConfig, SearchQueryBuilder linkBuilder) {
 		Terms facetValues = ((Terms) facetNameBucket.getAggregations().get(FACET_VALUES_AGG));
-		long absDocCount = 0;
-		for (String filterValue : facetFilter.getValues()) {
-			Bucket elementBucket = facetValues.getBucketByKey(filterValue);
-			if (elementBucket != null) {
-				long docCount = getDocumentCount(elementBucket);
-				facet.addEntry(buildFacetEntry(facetConfig, filterValue, docCount, linkBuilder));
-				absDocCount += docCount;
-			}
-		}
-		facet.setAbsoluteFacetCoverage(absDocCount);
-	}
-
-	private void fillFacet(Facet facet, Bucket facetNameBucket, FacetConfig facetConfig, SearchQueryBuilder linkBuilder) {
-		Terms facetValues = ((Terms) facetNameBucket.getAggregations().get(FACET_VALUES_AGG));
+		Set<String> filterValues = asSet(facetFilter.getValues());
 		long absDocCount = 0;
 		for (Bucket valueBucket : facetValues.getBuckets()) {
 			long docCount = getDocumentCount(valueBucket);
-			facet.addEntry(buildFacetEntry(facetConfig, valueBucket.getKeyAsString(), docCount, linkBuilder));
+			String facetValue = valueBucket.getKeyAsString();
+
+			String facetValueId = null;
+			Terms facetValueAgg = (Terms) valueBucket.getAggregations().get(CODE_VALUE_AGG);
+			if (facetValueAgg != null && facetValueAgg.getBuckets().size() > 0) {
+				facetValueId = facetValueAgg.getBuckets().get(0).getKeyAsString();
+			}
+
+			boolean isSelected = false;
+			if (facetFilter != null) {
+				if (facetFilter.isFilterOnId()) {
+					isSelected = filterValues.contains(facetValueId);
+				}
+				else {
+					isSelected = filterValues.contains(facetValue);
+				}
+			}
+
+			String link;
+			if (isSelected) {
+				if (facetFilter.isFilterOnId()) {
+					link = linkBuilder.withoutFilterAsLink(facetConfig, facetValueId);
+				}
+				else {
+					link = linkBuilder.withoutFilterAsLink(facetConfig, facetValue);
+				}
+			}
+			else {
+				if (facetFilter != null && facetFilter.isFilterOnId()) {
+					// as soon as we have a single ID filter and we're
+					link = linkBuilder.withFilterAsLink(facetConfig, facetValueId);
+				}
+				else {
+					link = linkBuilder.withFilterAsLink(facetConfig, facetValue);
+				}
+			}
+
+			FacetEntry facetEntry = new FacetEntry(facetValue, facetValueId, docCount, link, isSelected);
+
+			facet.addEntry(facetEntry);
 			absDocCount += docCount;
 		}
 		facet.setAbsoluteFacetCoverage(absDocCount);
 	}
 
-	private FacetEntry buildFacetEntry(FacetConfig facetConfig, String filterValue, long docCount, SearchQueryBuilder linkBuilder) {
-		boolean isSelected = linkBuilder.isFilterSelected(facetConfig, filterValue);
-		return new FacetEntry(
-				filterValue,
-				null, // TODO: fetch IDS
-				docCount,
-				isSelected ? linkBuilder.withoutFilterAsLink(facetConfig, filterValue) : linkBuilder.withFilterAsLink(facetConfig, filterValue),
-				isSelected);
+	private Set<String> asSet(String[] values) {
+		if (values.length == 0) return Collections.emptySet();
+		if (values.length == 1) return Collections.singleton(values[0]);
+
+		Set<String> hashedValues = new HashSet<>();
+		for (String val : values) {
+			hashedValues.add(val);
+		}
+		return hashedValues;
 	}
 
 	private long getDocumentCount(Bucket valueBucket) {

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/query/filter/TermResultFilterAdapter.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/query/filter/TermResultFilterAdapter.java
@@ -12,7 +12,7 @@ public class TermResultFilterAdapter implements InternalResultFilterAdapter<Term
 	public QueryBuilder getAsQuery(String fieldPrefix, TermResultFilter filter) {
 		return QueryBuilders.boolQuery()
 				.must(QueryBuilders.termQuery(fieldPrefix + "name", filter.getField().getName()))
-				.must(QueryBuilders.termsQuery(fieldPrefix + (filter.isFilterOnId() ? "code" : "value"), filter.getValues()));
+				.must(QueryBuilders.termsQuery(fieldPrefix + (filter.isFilterOnId() ? "id" : "value"), filter.getValues()));
 	}
 
 

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/query/filter/TermResultFilterAdapter.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/query/filter/TermResultFilterAdapter.java
@@ -12,7 +12,7 @@ public class TermResultFilterAdapter implements InternalResultFilterAdapter<Term
 	public QueryBuilder getAsQuery(String fieldPrefix, TermResultFilter filter) {
 		return QueryBuilders.boolQuery()
 				.must(QueryBuilders.termQuery(fieldPrefix + "name", filter.getField().getName()))
-				.must(QueryBuilders.termsQuery(fieldPrefix + (filter.isFilterOnId() ? "id" : "value"), filter.getValues()));
+				.must(QueryBuilders.termsQuery(fieldPrefix + (filter.isFilterOnId() ? "code" : "value"), filter.getValues()));
 	}
 
 

--- a/search-service/src/main/java/de/cxp/ocs/util/SearchParamsParser.java
+++ b/search-service/src/main/java/de/cxp/ocs/util/SearchParamsParser.java
@@ -26,6 +26,8 @@ import de.cxp.ocs.model.result.Sorting;
  */
 public class SearchParamsParser {
 
+	public final static String ID_FILTER_SUFFIX = ".id";
+
 	/**
 	 * Checks the parameter map for valid filters and extracts them into
 	 * InternalResultFilter objects.
@@ -48,7 +50,7 @@ public class SearchParamsParser {
 			String paramValue = p.getValue();
 
 			boolean isIdFilter = false;
-			if (paramName.endsWith(".id")) {
+			if (paramName.endsWith(ID_FILTER_SUFFIX)) {
 				isIdFilter = true;
 				paramName = paramName.substring(0, paramName.length() - 3);
 			}

--- a/search-service/src/main/java/de/cxp/ocs/util/SearchQueryBuilder.java
+++ b/search-service/src/main/java/de/cxp/ocs/util/SearchQueryBuilder.java
@@ -62,7 +62,11 @@ public class SearchQueryBuilder {
 		}
 		if (!params.filters.isEmpty()) {
 			for (InternalResultFilter filter : params.filters) {
-				urlParams.put(filter.getField().getName(), joinParameterValues(filter.getValues()));
+				String paramName = filter.getField().getName();
+				if (filter instanceof TermResultFilter && ((TermResultFilter) filter).isFilterOnId()) {
+					paramName += SearchParamsParser.ID_FILTER_SUFFIX;
+				}
+				urlParams.put(paramName, joinParameterValues(filter.getValues()));
 			}
 		}
 		if (!params.sortings.isEmpty()) {
@@ -146,7 +150,7 @@ public class SearchQueryBuilder {
 	public String withoutFilterAsLink(FacetConfig facetConfig, String... filterValues) {
 		String filterName = getFilterName(facetConfig);
 		String removeValue = joinParameterValues(filterValues);
-		if (isFilterSelected(facetConfig, removeValue)) {
+		if (isFilterSelected(filterName, removeValue)) {
 			URIBuilder linkBuilder = new URIBuilder(searchQueryLink);
 			if (facetConfig.isMultiSelect()) {
 				Optional<Set<String>> existingFilterValues = linkBuilder.getQueryParams().stream()
@@ -190,29 +194,30 @@ public class SearchQueryBuilder {
 	}
 
 	public String withFilterAsLink(FacetConfig facetConfig, String... filterValues) {
+		String filterName = getFilterName(facetConfig);
 		String filterValue = joinParameterValues(filterValues);
-		if (isFilterSelected(facetConfig, filterValue)) {
+		if (isFilterSelected(filterName, filterValue)) {
 			return searchQueryLink.toString();
 		}
-		if (searchQueryLink.toString().matches(".*[?&]" + Pattern.quote(facetConfig.getSourceField()) + "=.*")) {
+		if (searchQueryLink.toString().matches(".*[?&]" + Pattern.quote(filterName) + "=.*")) {
 			URIBuilder linkBuilder = new URIBuilder(searchQueryLink);
 			if (facetConfig.isMultiSelect()) {
 				Optional<String> otherValues = linkBuilder.getQueryParams().stream()
-						.filter(param -> facetConfig.getSourceField().equals(param.getName())).findFirst()
+						.filter(param -> filterName.equals(param.getName())).findFirst()
 						.map(NameValuePair::getValue);
-				linkBuilder.setParameter(facetConfig.getSourceField(), otherValues
+				linkBuilder.setParameter(filterName, otherValues
 						.map(val -> val + VALUE_DELIMITER + joinParameterValues(filterValue)).orElse(filterValue));
 			} else {
-				linkBuilder.setParameter(facetConfig.getSourceField(), filterValue);
+				linkBuilder.setParameter(filterName, filterValue);
 			}
 			try {
 				return linkBuilder.build().getRawQuery();
 			} catch (URISyntaxException e) {
 				throw new IllegalArgumentException(
-						"parameter caused URISyntaxException: " + facetConfig.getSourceField() + "=" + filterValue, e);
+						"parameter caused URISyntaxException: " + filterName + "=" + filterValue, e);
 			}
 		} else {
-			String newParam = facetConfig.getSourceField() + "=" + urlEncodeValue(filterValue);
+			String newParam = filterName + "=" + urlEncodeValue(filterValue);
 			String query = searchQueryLink.getRawQuery();
 			if (query == null || query.length() == 0)
 				return newParam;
@@ -221,9 +226,9 @@ public class SearchQueryBuilder {
 		}
 	}
 
-	public boolean isFilterSelected(FacetConfig facetConfig, String filterValue) {
+	public boolean isFilterSelected(String paramName, String filterValue) {
 		return searchQueryLink.getQuery() != null && searchQueryLink.getRawQuery().matches("(^|.*?&)"
-				+ Pattern.quote(urlEncodeValue(facetConfig.getSourceField())) + "=[^&]*?"
+				+ Pattern.quote(urlEncodeValue(paramName)) + "=[^&]*?"
 				+ Pattern.quote(urlEncodeValue(filterValue)) + "($|&|%2C).*");
 	}
 


### PR DESCRIPTION
API Change: The Attribute model has now a "name" property instead of "label" and "id". The name must be unique identifier that can also be used to map a label to the facets later on. It's called "name" because it will be used as field-name and as facet-name. The "code" property will stay and can be used as "identifier" for each different attribute value.

api: 0.9.0
indexer-service: 0.6.0
ocs-java-client: 0.6.0
search-service: 0.9.0