### PR TITLE
Feature/improve arranged search

### DIFF
--- a/ocs-java-client/pom.xml
+++ b/ocs-java-client/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.37.0</version>
+		<version>0.42.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 
 	<artifactId>ocs-java-client</artifactId>
-	<version>0.14.0</version>
+	<version>0.15.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<description>A ready to use client for the OCS API</description>

--- a/open-commerce-search-api/pom.xml
+++ b/open-commerce-search-api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.37.4</version>
+		<version>0.42.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 	 first by setting the correct api version at src/main/resources/openapi-configuration.json
 	 then my running 'mvn process-sources -P sync-openapi-spec'
 	-->
-	<version>0.17.1</version>
+	<version>0.18.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<description>An open and abstract search API that covers minimal search functionality</description>

--- a/open-commerce-search-api/src/main/java/de/cxp/ocs/model/params/ProductSet.java
+++ b/open-commerce-search-api/src/main/java/de/cxp/ocs/model/params/ProductSet.java
@@ -2,6 +2,8 @@ package de.cxp.ocs.model.params;
 
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
 @Schema(
 		discriminatorProperty = "type",
@@ -10,6 +12,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 				@DiscriminatorMapping(value = "dynamic", schema = DynamicProductSet.class),
 		})
 public abstract class ProductSet {
+
+	/**
+	 * If set to true, the result of that product set will be separated from the main result.
+	 * However facets won't be separated and still part of the main result's slice.
+	 */
+	@Getter
+	@Setter
+	public boolean asSeparateSlice = false;
 
 	public abstract String getType();
 

--- a/open-commerce-search-api/src/main/resources/openapi-configuration.json
+++ b/open-commerce-search-api/src/main/resources/openapi-configuration.json
@@ -3,7 +3,7 @@
     "cacheTTL": 0,
     "openAPI": {
         "info": {
-            "version": "0.16",
+            "version": "0.18.0-SNAPSHOT",
             "title": "Open Commerce Search Stack API",
             "description": "A common product search API that separates its usage from required search expertise",
             "contact": {

--- a/open-commerce-search-api/src/main/resources/openapi.yaml
+++ b/open-commerce-search-api/src/main/resources/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   title: Open Commerce Search Stack API
-  version: "0.16"
+  version: 0.18.0-SNAPSHOT
 paths:
   /indexer-api/v1/full/add:
     post:
@@ -485,17 +485,30 @@ components:
         limit:
           type: integer
           format: int32
+          description: The amount of products to return in the result
           minimum: 1
         offset:
           type: integer
           format: int32
+          description: The amount of products to omit from the whole result to select
+            the returned results.
           minimum: 0
         q:
           type: string
+          description: the user query
+          example: blue shirt
         sort:
           type: string
+          description: "Full sorting parameter value. This is the name of the sorting\
+            \ and optionally a dash as prefix, thats means the sorting should be descending.\
+            \ Several sorting criterion can be defined by separating the values using\
+            \ comma."
+          example: "sort=price,-name (price asc and name descending)"
         withFacets:
           type: boolean
+          description: flag to specify if facets should be returned with the requested
+            response. Should be set to false in case only the next batch of hits is
+            requested (e.g. for endless scrolling).
     Attribute:
       type: object
       description: "Rich model that can be used to represent a document's or product's\
@@ -598,6 +611,8 @@ components:
       - $ref: '#/components/schemas/ProductSet'
       - type: object
         properties:
+          asSeparateSlice:
+            type: boolean
           filters:
             type: object
             additionalProperties:
@@ -786,6 +801,8 @@ components:
           static: '#/components/schemas/StaticProductSet'
         propertyName: type
       properties:
+        asSeparateSlice:
+          type: boolean
         name:
           type: string
         size:
@@ -846,17 +863,30 @@ components:
         limit:
           type: integer
           format: int32
+          description: The amount of products to return in the result
           minimum: 1
         offset:
           type: integer
           format: int32
+          description: The amount of products to omit from the whole result to select
+            the returned results.
           minimum: 0
         q:
           type: string
+          description: the user query
+          example: blue shirt
         sort:
           type: string
+          description: "Full sorting parameter value. This is the name of the sorting\
+            \ and optionally a dash as prefix, thats means the sorting should be descending.\
+            \ Several sorting criterion can be defined by separating the values using\
+            \ comma."
+          example: "sort=price,-name (price asc and name descending)"
         withFacets:
           type: boolean
+          description: flag to specify if facets should be returned with the requested
+            response. Should be set to false in case only the next batch of hits is
+            requested (e.g. for endless scrolling).
     SearchResult:
       type: object
       properties:
@@ -963,6 +993,8 @@ components:
       - $ref: '#/components/schemas/ProductSet'
       - type: object
         properties:
+          asSeparateSlice:
+            type: boolean
           ids:
             type: array
             items:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>de.cxp.ocs</groupId>
 	<artifactId>ocs-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>0.41.0</version>
+	<version>0.42.0-SNAPSHOT</version>
 	<name>SearchHub Services - Parent</name>
 
 	<modules>
@@ -43,7 +43,7 @@
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>open-commerce-search-api</artifactId>
-				<version>0.17.1</version>
+				<version>0.18.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
@@ -63,7 +63,7 @@
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>search-service</artifactId>
-				<version>0.37.0</version>
+				<version>0.38.0-SNAPSHOT</version>
 			</dependency>
 			<!-- only including the suggest-service directly, because it depends on 
 				the other suggest modules -->
@@ -75,7 +75,7 @@
 			<dependency>
 				<groupId>de.cxp.ocs</groupId>
 				<artifactId>ocs-java-client</artifactId>
-				<version>0.13.0</version>
+				<version>0.15.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- serialization -->

--- a/search-service/pom.xml
+++ b/search-service/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>de.cxp.ocs</groupId>
 		<artifactId>ocs-parent</artifactId>
-		<version>0.41.0</version>
+		<version>0.42.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 
 	<artifactId>search-service</artifactId>
-	<version>0.37.0</version>
+	<version>0.38.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<!-- Import dependency management from Spring Boot -->

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/Searcher.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/Searcher.java
@@ -577,7 +577,7 @@ public class Searcher {
 		// XXX think about building parameters according to the actual performed
 		// search (e.g. with relaxed query or with implicit set filters)
 		srSlice.resultLink = SearchQueryBuilder.toLink(parameters).toString();
-		srSlice.matchCount = searchHits.getTotalHits().value;
+		srSlice.matchCount = searchHits.getTotalHits().value - heroIds.size();
 
 		Map<String, SortOrder> sortedFields = sortingHandler.getSortedNumericFields(parameters);
 

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/prodset/DynamicProductSetResolver.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/prodset/DynamicProductSetResolver.java
@@ -37,6 +37,7 @@ public class DynamicProductSetResolver implements ProductSetResolver {
 
 		// TODO: add caching
 		StaticProductSet resolved = search(dynamicProductSet, searcher, productSetParams);
+		resolved.setAsSeparateSlice(productSet.asSeparateSlice);
 		return resolved;
 	}
 

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/prodset/HeroProductHandler.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/prodset/HeroProductHandler.java
@@ -203,6 +203,7 @@ public class HeroProductHandler {
 					slice.setLabel(productSets[i].getName());
 					slice.setMatchCount(productSets[i].getSize());
 					slice.setHits(new ArrayList<>());
+					slice.nextOffset = internalParams.offset + searchResponse.getHits().getHits().length;
 					searchResult.slices.add(slice);
 				}
 				else {

--- a/search-service/src/main/java/de/cxp/ocs/elasticsearch/prodset/HeroProductHandler.java
+++ b/search-service/src/main/java/de/cxp/ocs/elasticsearch/prodset/HeroProductHandler.java
@@ -192,6 +192,8 @@ public class HeroProductHandler {
 			StaticProductSet[] productSets = internalParams.heroProductSets;
 			Map<String, Integer> productSetAssignment = new HashMap<>();
 			for (int i = 0; i < productSets.length; i++) {
+				if (!productSets[i].asSeparateSlice) continue;
+
 				for (int k = 0; k < productSets[i].ids.length; k++) {
 					productSetAssignment.putIfAbsent(productSets[i].ids[k], i);
 				}


### PR DESCRIPTION
This PR would change the default behavior for arranged search: per default all product-sets are now included into main, and only if a product-set declares `"asSeparateSlice": true` it will be separated from `main`.
However facets will still be included in main. @cgicgi  what do you think, should we have extra facets for such a slice as well?